### PR TITLE
Feature: Recent Test Plans Menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/hamster/__main__.py
+++ b/hamster/__main__.py
@@ -1,12 +1,13 @@
 import config, menu, utils
 
+
 def main():
     """
     Entry point of the Hamster - menu bar application.
     """
-    utils.prechecks(config.jmeter_plist, config.jmeter_home, config.jmeter_path)    
-    menu_items = utils.get_recent_jmeter_test_plans()
-    menu.DynamicMenuApp("JMeter", menu_items).run()
+    menu_builder = menu.DynamicMenuApp("JMeter")
+    menu_builder.run()
+
 
 if __name__ == "__main__":
     main()

--- a/hamster/config.py
+++ b/hamster/config.py
@@ -13,8 +13,9 @@ username = getpass.getuser()
 pattern = re.compile("recent_file_.*")
 
 jmeter_plist = f"/Users/{username}/Library/Preferences/org.apache.jmeter.plist"
-jmeter_home = config_parser.get('JMETER', 'HOME')
 
 
 def jmeter_path():
-    return jmeter_home + '/bin/jmeter'
+    jmeter_home = config_parser.get('JMETER', 'HOME')
+    jmeter_bin = jmeter_home + '/bin/jmeter'
+    return jmeter_home, jmeter_bin

--- a/hamster/config.py
+++ b/hamster/config.py
@@ -14,4 +14,7 @@ pattern = re.compile("recent_file_.*")
 
 jmeter_plist = f"/Users/{username}/Library/Preferences/org.apache.jmeter.plist"
 jmeter_home = config_parser.get('JMETER', 'HOME')
-jmeter_path = jmeter_home + '/bin/jmeter'
+
+
+def jmeter_path():
+    return jmeter_home + '/bin/jmeter'

--- a/hamster/menu.py
+++ b/hamster/menu.py
@@ -1,7 +1,7 @@
 import rumps
 import subprocess
 from utils import update_properties, show_splash_screen, prechecks, get_recent_jmeter_test_plans, sleep
-from config import jmeter_path, icon_path, properties_file_path, config_parser, jmeter_plist, jmeter_home
+from config import jmeter_path, icon_path, properties_file_path, config_parser, jmeter_plist
 
 
 class DynamicMenuApp(rumps.App):
@@ -25,8 +25,8 @@ class DynamicMenuApp(rumps.App):
         super(DynamicMenuApp, self).__init__(title, icon=icon_path, quit_button='Quit')
         self.menu = ['Launch JMeter', 'Recent Test Plans', None, 'View Config', 'Edit JMETER_HOME', None,
                      'Refresh', 'Help', 'About']
-        self.jmeter_path = jmeter_path()
-        prechecks(jmeter_plist, jmeter_home, self.jmeter_path)
+        self.jmeter_home, self.jmeter_bin = jmeter_path()
+        prechecks(jmeter_plist, self.jmeter_home, self.jmeter_bin)
         self.refresh_test_plans(delay=1)
 
     def refresh_test_plans(self, delay=5):
@@ -90,9 +90,11 @@ class DynamicMenuApp(rumps.App):
             response = window_builder.run()
 
             if response.clicked:
-                update_properties({'HOME': str(response.text.strip())})
+                updated_jmeter_home = response.text.strip()
+                update_properties({'HOME': str(updated_jmeter_home)})
                 config_parser.read(properties_file_path)
-                self.refresh_test_plans()
+                self.jmeter_home, self.jmeter_bin = jmeter_path()
+                self.refresh_test_plans(1)
         except Exception as e:
             rumps.alert("Error", e)
 
@@ -101,7 +103,7 @@ class DynamicMenuApp(rumps.App):
         Callback function for menu items.
         """
         try:
-            subprocess.Popen([self.jmeter_path, '-t', sender.title], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.Popen([self.jmeter_bin, '-t', sender.title], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             self.refresh_test_plans()
         except Exception as e:
             rumps.alert("Error", e)
@@ -112,7 +114,7 @@ class DynamicMenuApp(rumps.App):
         Launches JMeter without any test plan.
         """
         try:
-            subprocess.Popen([self.jmeter_path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.Popen([self.jmeter_bin], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         except Exception as e:
             rumps.alert("Error", e)
     

--- a/hamster/menu.py
+++ b/hamster/menu.py
@@ -25,7 +25,8 @@ class DynamicMenuApp(rumps.App):
         super(DynamicMenuApp, self).__init__(title, icon=icon_path, quit_button='Quit')
         self.menu = ['Launch JMeter', 'Recent Test Plans', None, 'View Config', 'Edit JMETER_HOME', None,
                      'Refresh', 'Help', 'About']
-        prechecks(jmeter_plist, jmeter_home, jmeter_path)
+        self.jmeter_path = jmeter_path()
+        prechecks(jmeter_plist, jmeter_home, self.jmeter_path)
         self.refresh_test_plans(delay=1)
 
     def refresh_test_plans(self, delay=5):
@@ -100,7 +101,7 @@ class DynamicMenuApp(rumps.App):
         Callback function for menu items.
         """
         try:
-            subprocess.Popen([jmeter_path, '-t', sender.title], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.Popen([self.jmeter_path, '-t', sender.title], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             self.refresh_test_plans()
         except Exception as e:
             rumps.alert("Error", e)
@@ -111,7 +112,7 @@ class DynamicMenuApp(rumps.App):
         Launches JMeter without any test plan.
         """
         try:
-            subprocess.Popen([jmeter_path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            subprocess.Popen([self.jmeter_path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         except Exception as e:
             rumps.alert("Error", e)
     

--- a/hamster/utils.py
+++ b/hamster/utils.py
@@ -1,22 +1,13 @@
-import os
 import plistlib
-import psutil
 import time
-import sys
 import rumps
 
 from pathlib import Path
 from config import properties_file_path, config_parser, jmeter_plist, pattern, icon_path
 
 
-def restart(delay):
-    if delay:
-        time.sleep(delay)        
-    else:
-        time.sleep(1)
-    python = sys.executable
-    psutil.Popen([python] + sys.argv)
-    psutil.Process(os.getpid()).terminate()   
+def sleep(delay=1):
+    time.sleep(delay)
 
 
 def refresh_plist(plist_path):
@@ -49,13 +40,13 @@ def get_recent_jmeter_test_plans():
                 recent_files = {k: v for k, v in pl['/org/apache/jmeter/']["gui/"]["action/"].items() if pattern.match(k)}
 
                 # escape file names with spaces
-                recent_files = {k: v.replace(' ', '\\ ') for k, v in recent_files.items()}
+                recent_files = {k: v for k, v in recent_files.items()}
                 recent_files = dict(sorted(recent_files.items()))
                 recent_files = list(recent_files.values())
                 
                 # check if recent_files is empty
-                if not recent_files:
-                    recent_files.append("No recent JMeter test plans files found.")
+                # if not recent_files:
+                #     recent_files.append("No recent JMeter test plans files found.")
         except Exception as e:
             rumps.alert("Error", e)
         

--- a/hamster/utils.py
+++ b/hamster/utils.py
@@ -44,9 +44,6 @@ def get_recent_jmeter_test_plans():
                 recent_files = dict(sorted(recent_files.items()))
                 recent_files = list(recent_files.values())
                 
-                # check if recent_files is empty
-                # if not recent_files:
-                #     recent_files.append("No recent JMeter test plans files found.")
         except Exception as e:
             rumps.alert("Error", e)
         


### PR DESCRIPTION
**Change Summary:**
* New Menu Item - `Recent Test Plans`
    - Earlier test plans were displayed directly on the app. With the new changes all the recent Test Plans will be available under this menu.
    - Automatically refreshes recent test plan loaded - reverse chronological order
 * Removed restart and added refresh. 
 * Remove replace string for file names
 * Refactor recent test plan file loading logic